### PR TITLE
feat(displaycards.tsx): added progress bar to the display cards UI

### DIFF
--- a/src/pages/DisplayCards.tsx
+++ b/src/pages/DisplayCards.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { Card, Button, Typography, Layout } from "antd";
+import { Card, Button, Typography, Layout, Progress } from "antd";
 
 import logo from "../assets/images/logo.svg";
 import "../styles/DisplayCards.css";
@@ -11,13 +11,17 @@ const initialValues = {
 
 const DisplayCards: React.FC = () => {
   const [state] = useState(initialValues);
+
   const onBackClick = () => {
-    // TODO: Write code here to redirect to course info screen
+    // TODO: Write code here to redirect to course info screen or to previous card
   };
 
   const onSkipClick = () => {
-    // TODO: Write code here to redirect to instructions screen
+    // TODO: Write code here to redirect to the next card or another incomplete card
   };
+
+  const progressMade = { completed: 8, total: 14 };
+
   return (
     <div className="DisplayCards">
       <Layout.Header className="DisplayCards-Header">
@@ -47,6 +51,31 @@ const DisplayCards: React.FC = () => {
           >
             <Typography className="Navigation-Button-Text">Back</Typography>
           </Button>
+          <div className="Progress">
+            <Typography>
+              Completed: {progressMade.completed}/{progressMade.total}{" "}
+              (Required: 8)
+            </Typography>
+            <Progress
+              className="Progress-Bar"
+              strokeColor={
+                progressMade.completed >= 8
+                  ? {
+                      from: "#32C5FF",
+                      to: "#00D49B",
+                    }
+                  : {
+                      from: "#7491F2",
+                      to: "#32C5FF",
+                    }
+              }
+              trailColor="#C3C6D4"
+              status={progressMade.completed >= 8 ? "success" : "active"}
+              percent={(progressMade.completed / progressMade.total) * 100}
+              showInfo={false}
+              strokeWidth={20}
+            />
+          </div>
           <Button
             type="primary"
             className="NavigationButton"

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,17 +1,20 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { withRouter, RouteComponentProps } from "react-router-dom";
 
 import { Button, Typography } from "antd";
 import logo from "../assets/images/logo.svg";
 import "../styles/Homepage.css";
 
-const Homepage: React.FC = () => {
+type RouterProps = RouteComponentProps;
+
+const Homepage: React.FC<RouteComponentProps> = (props) => {
   const onPlayClick = () => {
-    // TODO: Write code here to redirect to course info screen
+    props.history.push("/DisplayCards");
   };
 
   const onInstructionsClick = () => {
-    // TODO: Write code here to redirect to instructions screen
+    // TODO: Change code here to redirect to instructions screen (add URL)
+    // props.history.push("URL-HERE");
   };
 
   return (
@@ -26,11 +29,9 @@ const Homepage: React.FC = () => {
         </Typography>
       </div>
       <div className="Buttons-Container">
-        <Link to="/DisplayCards">
-          <Button className="Button" onClick={onPlayClick}>
-            <Typography className="Button-Text">Play</Typography>
-          </Button>
-        </Link>
+        <Button className="Button" onClick={onPlayClick}>
+          <Typography className="Button-Text">Play</Typography>
+        </Button>
         <Button type="default" className="Button" onClick={onInstructionsClick}>
           <Typography className="Button-Text">Instructions</Typography>
         </Button>
@@ -39,4 +40,4 @@ const Homepage: React.FC = () => {
   );
 };
 
-export default Homepage;
+export default withRouter(Homepage);

--- a/src/styles/DisplayCards.css
+++ b/src/styles/DisplayCards.css
@@ -84,6 +84,7 @@
 
 .Navigation {
   justify-content: space-between;
+  align-items: center;
   display: flex;
   flex-direction: row;
   margin: 15px 30px;
@@ -97,4 +98,17 @@
 
 .Navigation-Button-Text {
   font-size: 30px;
+}
+
+.Progress {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding-bottom: 15px;
+}
+
+.Progress-Bar {
+  width: 65%;
+  margin: 5px 0px 0px;
 }


### PR DESCRIPTION
Added a progress bar to the display cards UI that can dynamically calculate progress and display it

### Purpose
Added a progress card to the statement selection cards screen so that the user is aware of how much they have completed/how far they have left to go.
[HRT-30](https://softeng761team5.atlassian.net/browse/HRT-30)

### Approach
Added an antd Progress component and styled it according to the hi-fi designs

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!--
If this PR contains a breaking change, describe the impact and migration path for existing applications below.
-->

### Screenshots before and after this change (required for UI changes)

#### Does this PR involve a UI change?

- [x] Yes
- [ ] No

#### Screenshot(s) of UI before this PR
<img width="750" alt="Screen Shot 2020-09-11 at 2 10 09 AM" src="https://user-images.githubusercontent.com/42624632/92742658-f4dd1500-f3d3-11ea-9844-92ea8dc49085.png">

#### Screenshot(s) of UI after this PR
<img width="750" alt="Screen Shot 2020-09-11 at 2 11 08 AM" src="https://user-images.githubusercontent.com/42624632/92742779-11794d00-f3d4-11ea-82db-5e581593fb6e.png">

<img width="750" alt="Screen Shot 2020-09-11 at 2 08 49 AM" src="https://user-images.githubusercontent.com/42624632/92742473-c3644980-f3d3-11ea-9264-8257b1b2e40b.png">

