### PR TITLE
HRT 37 edit dimension user explanation

### DIFF
--- a/src/components/Dimension.tsx
+++ b/src/components/Dimension.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { ChangeEvent } from "react";
 
 import { Card, Slider, Typography } from "antd";
 import "../styles/Dimension.css";
+import TextArea from "antd/lib/input/TextArea";
 
 interface DimensionProps {
   dimensionValue: string;
@@ -14,6 +15,7 @@ interface DimensionProps {
 interface MainProps {
   dimension: DimensionProps;
   sliderUpdate: (value: number) => void;
+  userExplanationUpdate?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 interface SliderMarks {
@@ -38,11 +40,21 @@ const Dimension: React.FC<MainProps> = (props: MainProps) => {
           onChange={props.sliderUpdate}
           marks={props.dimension.marks}
         />
-        <Typography className="User-Explanation">
-          {props.dimension.userExplanation.length > 0
-            ? '"' + props.dimension.userExplanation + '"'
-            : ""}
-        </Typography>
+        {props.dimension.isPreview ? (
+          <Typography className="User-Explanation">
+            {props.dimension.userExplanation.length > 0
+              ? '"' + props.dimension.userExplanation + '"'
+              : ""}
+          </Typography>
+        ) : (
+          <TextArea
+            className="User-Explanation"
+            value={props.dimension.userExplanation}
+            onChange={props.userExplanationUpdate}
+            placeholder="Explain your position on the dimension here..."
+            rows={4}
+          />
+        )}
       </div>
     </Card>
   );

--- a/src/components/Dimension.tsx
+++ b/src/components/Dimension.tsx
@@ -48,11 +48,11 @@ const Dimension: React.FC<MainProps> = (props: MainProps) => {
           </Typography>
         ) : (
           <TextArea
-            className="User-Explanation"
+            className="User-Explanation-Edit"
             value={props.dimension.userExplanation}
             onChange={props.userExplanationUpdate}
             placeholder="Explain your position on the dimension here..."
-            rows={4}
+            rows={3}
           />
         )}
       </div>

--- a/src/pages/DisplayCards.tsx
+++ b/src/pages/DisplayCards.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, ChangeEvent } from "react";
 
 import { Card, Button, Typography, Tooltip, Progress } from "antd";
 import Header from "../components/Header";
@@ -151,6 +151,10 @@ const DisplayCards: React.FC = () => {
     });
   };
 
+  const onUserExplanationChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setDimension({ ...dimension, userExplanation: event.target.value });
+  };
+
   function getLeftColour(value: number) {
     var hue = 344.7;
     var value = 87 + (13 / 100) * value;
@@ -271,7 +275,11 @@ const DisplayCards: React.FC = () => {
           </div>
           {isCardSelected ? (
             <Dimension
-              {...{ dimension: dimension, sliderUpdate: onDimensionChange }}
+              {...{
+                dimension: dimension,
+                sliderUpdate: onDimensionChange,
+                userExplanationUpdate: onUserExplanationChange,
+              }}
             />
           ) : (
             ""

--- a/src/styles/Dimension.css
+++ b/src/styles/Dimension.css
@@ -24,6 +24,12 @@
   margin-left: 2px;
 }
 
+.User-Explanation-Edit {
+  margin-top: 2%;
+  font-size: 16px;
+  margin-left: 2px;
+}
+
 .Slider {
   margin-top: 2%;
 }

--- a/src/styles/Dimension.css
+++ b/src/styles/Dimension.css
@@ -18,13 +18,6 @@
   margin: 0px;
 }
 
-.Captions-Container {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  font-size: 20px;
-}
-
 .User-Explanation {
   margin-top: 3%;
   font-size: 16px;


### PR DESCRIPTION
### Purpose

<!---
Describe the problem or feature.
Consider providing an overview of why the work is taking place (with any relevant links); don’t assume familiarity with the history.
-->

- Changed from following Mitchell's edit card style for editing the user explanation to a text area
- Text area for editing user explanation is only on display cards page and not preview page
- When there is an existing user statement, this will be displayed and editable otherwise a placeholder is shown
- When the user edits the statement, this changes the state

<!---
Link to the related issues [KEY-000](link)
e.g [HRT-27](https://softeng761team5.atlassian.net/browse/HRT-27)
--->

[HRT-37](https://softeng761team5.atlassian.net/browse/HRT-37)

<!-- []() -->
<!-- []() -->

### Approach

<!---
How does this change address the problem
--->

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!--
If this PR contains a breaking change, describe the impact and migration path for existing applications below.
-->

### Screenshots before and after this change (required for UI changes)

#### Does this PR involve a UI change?

- [X] Yes
- [ ] No

#### Screenshot(s) of UI before this PR

<!---
Required if there is UI change
--->

![image](https://user-images.githubusercontent.com/37464749/94356596-cd34bf00-00ec-11eb-8957-5da32dbc71f4.png)


#### Screenshot(s) of UI after this PR

Ignore my Grammarly circle haha

<!---
Required if there is UI change
--->

![image](https://user-images.githubusercontent.com/37464749/94356582-b2fae100-00ec-11eb-957d-5a23285afc7e.png)

