### PR TITLE
feat(front end): add types to dimensions and associate them with colours

### DIFF
--- a/src/components/Dimension.tsx
+++ b/src/components/Dimension.tsx
@@ -52,6 +52,9 @@ const Dimension: React.FC<DimensionProps> = (props: DimensionProps) => {
           rows={3}
         />
       )}
+      <Typography className="Dimension-Type-Text">
+        Type: {props.dimension.type}
+      </Typography>
     </Card>
   );
 };

--- a/src/components/PreviewDimension.tsx
+++ b/src/components/PreviewDimension.tsx
@@ -29,7 +29,10 @@ const PreviewDimension: React.FC<PreviewDimensionProps> = (props, ref) => {
   const [colours, setColours] = useState(
     currentDimension.userSelectedSliderPos === -1
       ? DEFAULT_COLOURS
-      : getColours(currentDimension.userSelectedSliderPos)
+      : getColours(
+          currentDimension.userSelectedSliderPos,
+          currentDimension.type
+        )
   );
 
   useEffect(() => {
@@ -50,7 +53,10 @@ const PreviewDimension: React.FC<PreviewDimensionProps> = (props, ref) => {
       setColours(
         currentDimension.userSelectedSliderPos === -1
           ? DEFAULT_COLOURS
-          : getColours(currentDimension.userSelectedSliderPos)
+          : getColours(
+              currentDimension.userSelectedSliderPos,
+              currentDimension.type
+            )
       );
     }
   }, [props.fullDimensionView]);
@@ -104,7 +110,7 @@ const PreviewDimension: React.FC<PreviewDimensionProps> = (props, ref) => {
       props.previewSliderPosChange(value, props.dimension.name);
     }
     setDimension({ ...currentDimension, userSelectedSliderPos: value });
-    setColours(getColours(value));
+    setColours(getColours(value, currentDimension.type));
   };
 
   const onUserExplanationChange = (event: ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/pages/DisplayCards.tsx
+++ b/src/pages/DisplayCards.tsx
@@ -36,7 +36,10 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
   const [colours, setColours] = useState(
     currentDimension.userSelectedSliderPos === -1
       ? DEFAULT_COLOURS
-      : getColours(currentDimension.userSelectedSliderPos)
+      : getColours(
+          currentDimension.userSelectedSliderPos,
+          currentDimension.type
+        )
   );
   const [progress, setProgress] = useState({
     completed: allDimensions.filter((dim) => dim.userSelectedSliderPos !== -1)
@@ -68,7 +71,10 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
     setColours(
       allDimensions[newIndex].userSelectedSliderPos === -1
         ? DEFAULT_COLOURS
-        : getColours(allDimensions[newIndex].userSelectedSliderPos)
+        : getColours(
+            allDimensions[newIndex].userSelectedSliderPos,
+            allDimensions[newIndex].type
+          )
     );
   };
 
@@ -142,7 +148,7 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
 
   const onSliderPosChange = (value: number) => {
     setDimension({ ...currentDimension, userSelectedSliderPos: value });
-    setColours(getColours(value));
+    setColours(getColours(value, currentDimension.type));
   };
 
   const onUserExplanationChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -159,7 +165,9 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
           </Typography>
           <div className="Cards-Container">
             <Card
-              className="Card"
+              className={`Card ${
+                currentDimension.type === "Practice" ? "Pink" : "Blue"
+              }`}
               onClick={() => {
                 if (!leftState.isEditing) {
                   onCardClick(CardSide.Left);
@@ -208,7 +216,9 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
               )}
             </Card>
             <Card
-              className="Card"
+              className={`Card ${
+                currentDimension.type === "Practice" ? "Pink" : "Blue"
+              }`}
               onClick={() => {
                 if (!rightState.isEditing) {
                   onCardClick(CardSide.Right);

--- a/src/pages/PrintCards.tsx
+++ b/src/pages/PrintCards.tsx
@@ -12,8 +12,8 @@ import { API_DOMAIN } from "../config";
 
 import charts from "../dummyData/charts";
 
-const PracticeBGColour = "#b7dee8";
-const BeliefBGColour = "#fac090";
+const PracticeBGColour = "#ffc4d3";
+const BeliefBGColour = "#c4ddff";
 class ComponentToPrint extends React.Component {
   render() {
     const allDimensions = charts[0].dimensions;

--- a/src/styles/Dimension.css
+++ b/src/styles/Dimension.css
@@ -1,6 +1,6 @@
 .Card-Dimension {
-  min-height: 300px;
-  height: 35vh;
+  min-height: 315px;
+  height: 36.5vh;
   padding: 30px;
   margin: 10px 30px 150px 30px;
   box-shadow: 0 2.8px 2.2px rgba(0, 0, 0, 0.034),
@@ -14,7 +14,7 @@
 }
 
 .Card-Preview {
-  min-height: 350px;
+  min-height: 250px;
   width: 40vw;
   min-width: 600px;
   margin: 30px;
@@ -84,4 +84,10 @@
 
 .Clickable:hover {
   color: #ff9cb8;
+}
+
+.Dimension-Type-Text {
+  margin: 15px 0px;
+  font-size: 16px;
+  font-weight: 500;
 }

--- a/src/styles/DisplayCards.css
+++ b/src/styles/DisplayCards.css
@@ -51,9 +51,16 @@
 }
 
 .Card:hover {
-  background-color: #ffc4d3 !important;
   color: #212121;
   border: none;
+}
+
+.Blue:hover {
+  background-color: #c4ddff !important;
+}
+
+.Pink:hover {
+  background-color: #ffc4d3 !important;
 }
 
 .Card-Text {

--- a/src/utils/cards.ts
+++ b/src/utils/cards.ts
@@ -3,8 +3,8 @@ export const DEFAULT_COLOURS = {
   rightCardColour: "#FFFFFF",
 };
 
-export const getColours = (value: number) => {
-  const hue = 344.7;
+export const getColours = (value: number, dimensionType: string) => {
+  const hue = dimensionType === "Practice" ? 344.7 : 215.7;
   const leftValue = 87 + (13 / 100) * value;
   const leftColour = ["hsl(", hue, ",100%,", leftValue, "%)"].join("");
 


### PR DESCRIPTION
Add types to dimensions and associate them with colours

BREAKING CHANGE: Function parameters have changed for getColours

### Purpose

Display dimension types and associate the two different types with two different colours.
[HRT-76](https://softeng761team5.atlassian.net/browse/HRT-76)

### Approach

Change getColours function and change CSS

### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!--
If this PR contains a breaking change, describe the impact and migration path for existing applications below.
-->

May need to update any parameters passed into the getColours function in your branch if you've added it in any other location.

### Screenshots before and after this change (required for UI changes)

#### Does this PR involve a UI change?

- [x] Yes
- [ ] No

#### Screenshot(s) of UI before this PR
<img width="1000" alt="Screen Shot 2020-10-02 at 8 18 59 PM" src="https://user-images.githubusercontent.com/42624632/94897617-8419ac00-04ec-11eb-9dc3-41234eb4405e.png">

#### Screenshot(s) of UI after this PR
<img width="1000" alt="Screen Shot 2020-10-02 at 8 10 37 PM" src="https://user-images.githubusercontent.com/42624632/94897592-782dea00-04ec-11eb-9a77-316be5e9d17e.png">
<img width="1000" alt="Screen Shot 2020-10-02 at 8 10 55 PM" src="https://user-images.githubusercontent.com/42624632/94897602-7d8b3480-04ec-11eb-87fe-b52c8ec3310b.png">

