### PR TITLE
feat(front end): save dimension on display cards and fix text area bug

### DIFF
--- a/src/pages/DisplayCards.tsx
+++ b/src/pages/DisplayCards.tsx
@@ -11,6 +11,7 @@ import { CardSide } from "../types/card";
 import {
   Dimension as DimensionType,
   createDimension,
+  createBackendDimension,
 } from "../types/dimension";
 
 import { DEFAULT_COLOURS, getColours } from "../utils/cards";
@@ -119,21 +120,19 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
 
   const saveCurrentDimension = async (): Promise<void> => {
     // TODO: Fix this PUT request
-    // const dimension = createBackendDimension(
-    //   chart!.dimensions[dimensionIndex]
-    // );
-    // const response = await fetch(
-    //   `${API_DOMAIN}dimensions/` + chart!.dimensions[dimensionIndex].id,
-    //   {
-    //     method: "PUT",
-    //     body: JSON.stringify(dimension),
-    //     headers: {
-    //       Authorization: `Bearer ${cookies["accessToken"]}`,
-    //       "Content-Type": "application/json",
-    //       Accept: "application/json",
-    //     },
-    //   }
-    // );
+    const dimension = createBackendDimension(allDimensions![dimensionIndex]);
+    await fetch(
+      `${API_DOMAIN}dimensions/` + allDimensions![dimensionIndex].id,
+      {
+        method: "PUT",
+        body: JSON.stringify(dimension),
+        headers: {
+          Authorization: `Bearer ${cookies["accessToken"]}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      }
+    );
   };
 
   const setNewDimension = (newIndex: number) => {
@@ -325,7 +324,7 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
         if (index === dimensionIndex) {
           return {
             ...dimension,
-            serExplanation: event.target.value,
+            userExplanation: event.target.value,
           };
         } else {
           return dimension;


### PR DESCRIPTION
save dimension on display cards and fix text area bug

### Purpose

Saves dimension on Display cards when user clicks next, to save chart progress

[HRT-38](https://softeng761team5.atlassian.net/browse/HRT-38)

### Approach
PUT request made to the server to save changes.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!--
If this PR contains a breaking change, describe the impact and migration path for existing applications below.
-->

### Screenshots before and after this change (required for UI changes)

#### Does this PR involve a UI change?

- [ ] Yes
- [x] No

#### Screenshot(s) of UI before this PR

<!---
Required if there is UI change
--->

#### Screenshot(s) of UI after this PR

<!---
Required if there is UI change
--->
