### PR TITLE
feat(displaycards): display incomplete chart modal

### DIFF
--- a/src/pages/DisplayCards.tsx
+++ b/src/pages/DisplayCards.tsx
@@ -3,7 +3,7 @@ import { useCookies } from "react-cookie";
 import * as QueryString from "query-string";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 
-import { Card, Button, Typography, Tooltip, Progress, Spin } from "antd";
+import { Card, Button, Typography, Tooltip, Progress, Spin, Modal } from "antd";
 import Header from "../components/Header";
 import Dimension from "../components/Dimension";
 
@@ -32,6 +32,7 @@ const DEFAULT_PROGRESS = {
 const DisplayCards: React.FC<RouteComponentProps> = (props) => {
   const [cookies] = useCookies(["accessToken"]);
   const isPrevPagePreview = window.history.state?.state?.prevPage === "Preview";
+  const [showIncompleteModal, setShowIncompleteModal] = useState(false);
 
   const params = QueryString.parse(props.location.search);
   const [allDimensions, setAllDimensions] = useState<
@@ -168,8 +169,13 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
         );
       } else {
         // Display modal to say at least 8 dimensions must be completed
+        setShowIncompleteModal(true);
       }
     }
+  };
+
+  const handleOk = () => {
+    setShowIncompleteModal(false);
   };
 
   const onCardClick = (side: CardSide) => {
@@ -333,10 +339,36 @@ const DisplayCards: React.FC<RouteComponentProps> = (props) => {
     );
   };
 
+  const toCompleteDimensions = () => {
+    let toComplete = 8 - progress.completed;
+    return toComplete;
+  };
+
   if (allDimensions) {
     return (
       <div className="DisplayCards">
         <Header />
+        <Modal
+          title="Incomplete Chart"
+          centered
+          visible={showIncompleteModal}
+          footer={[
+            <Button
+              key="ok"
+              type="primary"
+              onClick={handleOk}
+              className="Modal-Button"
+            >
+              Ok
+            </Button>,
+          ]}
+        >
+          <p>
+            You must complete at least 8 dimensions to save your chart.
+            <br />
+            Please complete {toCompleteDimensions()} more dimensions.
+          </p>
+        </Modal>
         <div className="Cards-Content">
           <div style={{ width: "100%" }}>
             <Typography className="Statement">

--- a/src/styles/DisplayCards.css
+++ b/src/styles/DisplayCards.css
@@ -130,3 +130,9 @@
   width: 100vw;
   height: 100vh;
 }
+
+.Modal-Button {
+  box-shadow: 0px 0px 0px 0px;
+  border-radius: 10px;
+  margin-left: auto;
+}


### PR DESCRIPTION
### Purpose

<!---
Describe the problem or feature.
Consider providing an overview of why the work is taking place (with any relevant links); don’t assume familiarity with the history.
-->

- Display a modal when the user hasn't completed 8 dimensions
- Tells them how many more to do

<!---
Link to the related issues [KEY-000](link)
e.g [HRT-27](https://softeng761team5.atlassian.net/browse/HRT-27)
--->

[HRT-89](https://softeng761team5.atlassian.net/browse/HRT-89)

<!-- []() -->
<!-- []() -->

### Approach

<!---
How does this change address the problem
--->

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!--
If this PR contains a breaking change, describe the impact and migration path for existing applications below.
-->

### Screenshots before and after this change (required for UI changes)

#### Does this PR involve a UI change?

- [x] Yes
- [ ] No

#### Screenshot(s) of UI before this PR

<!---
Required if there is UI change
--->

![image](https://user-images.githubusercontent.com/37464749/95052003-aad51e00-074a-11eb-86f9-267303122bc3.png)


#### Screenshot(s) of UI after this PR

<!---
Required if there is UI change
--->

![image](https://user-images.githubusercontent.com/37464749/95051974-9d1f9880-074a-11eb-9661-6ed6641ff21c.png)
