### PR TITLE
fix(front end): all dimensions being compared are visible

### DIFF
--- a/src/components/DimensionComparator.tsx
+++ b/src/components/DimensionComparator.tsx
@@ -45,7 +45,7 @@ const DimensionComparator: React.FC<DimensionComparatorProps> = (
               ", " +
               moment(props.dates[index]).format("DD MMM YYYY (HH:mmA)")
             }
-            style={{ position: "relative", textAlign: "center" }}
+            style={{ position: "relative" }}
             color={Object.values(colours)[index]}
           >
             <div
@@ -64,7 +64,7 @@ const DimensionComparator: React.FC<DimensionComparatorProps> = (
         style: { color: Object.values(colours)[index], fontSize: "0.8em" },
         label: (
           <Tooltip
-            style={{ position: "relative", textAlign: "center" }}
+            style={{ position: "relative" }}
             title={moment(props.dates[index]).format("DD MMM YYYY (HH:mmA)")}
             color={Object.values(colours)[index]}
           >

--- a/src/components/DimensionComparator.tsx
+++ b/src/components/DimensionComparator.tsx
@@ -41,11 +41,11 @@ const DimensionComparator: React.FC<DimensionComparatorProps> = (
         label: (
           <Tooltip
             title={
-              moment(labeled[mark].value).format("DD MMM, HH:mmA") +
+              moment(labeled[mark].value).format("DD MMM YYYY (HH:mmA)") +
               ", " +
-              moment(props.dates[index]).format("DD MMM, HH:mmA")
+              moment(props.dates[index]).format("DD MMM YYYY (HH:mmA)")
             }
-            style={{ position: "relative" }}
+            style={{ position: "relative", textAlign: "center" }}
             color={Object.values(colours)[index]}
           >
             <div
@@ -64,8 +64,8 @@ const DimensionComparator: React.FC<DimensionComparatorProps> = (
         style: { color: Object.values(colours)[index], fontSize: "0.8em" },
         label: (
           <Tooltip
-            style={{ position: "relative" }}
-            title={moment(props.dates[index]).format("DD MMM, HH:mmA")}
+            style={{ position: "relative", textAlign: "center" }}
+            title={moment(props.dates[index]).format("DD MMM YYYY (HH:mmA)")}
             color={Object.values(colours)[index]}
           >
             <div
@@ -112,7 +112,7 @@ const DimensionComparator: React.FC<DimensionComparatorProps> = (
                     color: labeled[dimension.userSelectedSliderPos].color,
                   }}
                 >
-                  {moment(props.dates[index]).format("DD MMM, HH:mmA")}
+                  {moment(props.dates[index]).format("DD MMM YYYY (HH:mmA)")}
                 </span>
               }
               key={index}

--- a/src/pages/CompareCharts.tsx
+++ b/src/pages/CompareCharts.tsx
@@ -112,14 +112,28 @@ const CompareCharts: React.FC<RouteComponentProps> = (props) => {
             <Typography className="Preview-Title">{courseName}</Typography>
             <Col className="Charts-Compare-Row">
               {chartsToCompare[0].dimensions.map((item, index) => {
-                if (item.userSelectedSliderPos !== -1) {
+                if (
+                  chartsToCompare.some((chart) => {
+                    return chart.dimensions[index].userSelectedSliderPos !== -1;
+                  })
+                ) {
                   return (
                     <DimensionComparator
                       {...{
-                        dimensions: chartsToCompare.map(
-                          (chart) => chart.dimensions[index]
-                        ),
-                        dates: chartsToCompare.map((chart) => chart.createdAt),
+                        dimensions: chartsToCompare
+                          .filter(
+                            (chart) =>
+                              chart.dimensions[index].userSelectedSliderPos !==
+                              -1
+                          )
+                          .map((chart) => chart.dimensions[index]),
+                        dates: chartsToCompare
+                          .filter(
+                            (chart) =>
+                              chart.dimensions[index].userSelectedSliderPos !==
+                              -1
+                          )
+                          .map((chart) => chart.createdAt),
                         isPreview: true,
                         key: item.name,
                       }}

--- a/src/styles/custom-antd.css
+++ b/src/styles/custom-antd.css
@@ -23990,7 +23990,7 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   min-height: 32px;
   padding: 6px 8px;
   color: #fff;
-  text-align: left;
+  text-align: center;
   text-decoration: none;
   word-wrap: break-word;
   background-color: rgba(0, 0, 0, 0.75);


### PR DESCRIPTION
All dimensions being compared as visible if at least one chart has that dimension completed

### Purpose

Compared dimensions would only show up if the first chart being compared had the dimension filled out. This was incorrect as we will want to see the dimension if other charts have filled it out.
[HRT-96](https://softeng761team5.atlassian.net/browse/HRT-96)


### Approach

Changed conditional rendered to show the dimension if at least one chart has it completed

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!--
If this PR contains a breaking change, describe the impact and migration path for existing applications below.
-->

### Screenshots before and after this change (required for UI changes)

#### Does this PR involve a UI change?

- [ ] Yes
- [x] No

#### Screenshot(s) of UI before this PR

<!---
Required if there is UI change
--->

#### Screenshot(s) of UI after this PR

<!---
Required if there is UI change
--->
